### PR TITLE
Investigate bot channel admin error

### DIFF
--- a/app/bot/channels.py
+++ b/app/bot/channels.py
@@ -14,7 +14,7 @@ from pyrogram.types import (
     CallbackQuery,
     Chat
 )
-from pyrogram.enums import ParseMode, ChatType
+from pyrogram.enums import ParseMode, ChatType, ChatMemberStatus
 from pyrogram.errors import (
     UserNotParticipant,
     ChatAdminRequired,
@@ -112,7 +112,7 @@ class ChannelManager:
             logger.info(f"حالة البوت: {bot_member.status}")
             
             # التحقق من أن البوت مشرف
-            if bot_member.status in ["administrator", "creator"]:
+            if bot_member.status in [ChatMemberStatus.ADMINISTRATOR, ChatMemberStatus.OWNER]:
                 logger.info(f"✅ البوت مشرف في {chat.title}")
                 return True, chat
             else:


### PR DESCRIPTION
Fix bot's channel administration check to use `ChatMemberStatus` enums.

The bot was failing to recognize itself as an administrator in channels because the comparison logic was checking `bot_member.status` against string literals (`"administrator"`, `"creator"`) instead of the actual `ChatMemberStatus` enum values returned by Pyrogram. This led to the bot incorrectly reporting that it was not an administrator despite having the necessary permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf87f46b-9386-4396-9dc5-f1b399849c34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf87f46b-9386-4396-9dc5-f1b399849c34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

