### PR TITLE
Search and filter logs

### DIFF
--- a/app/web/main.py
+++ b/app/web/main.py
@@ -775,16 +775,16 @@ async def telegram_webhook(request: Request) -> Response:
                     await answer_cbq()
                 elif data.startswith("header_menu_"):
                     cid = int(data.split("_")[-1])
-                    await header_menu(bot, type("obj", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, *args, **kwargs)})(), user_id, cid)
+                    await header_menu(bot, type("obj", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=args[0] if args else kwargs.get('text'), reply_markup=kwargs.get('reply_markup'), parse_mode=kwargs.get('parse_mode'))})(), user_id, cid)
                     await answer_cbq()
                 elif data.startswith("footer_menu_"):
                     cid = int(data.split("_")[-1])
-                    await footer_menu(bot, type("obj", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, *args, **kwargs)})(), user_id, cid)
+                    await footer_menu(bot, type("obj", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=args[0] if args else kwargs.get('text'), reply_markup=kwargs.get('reply_markup'), parse_mode=kwargs.get('parse_mode'))})(), user_id, cid)
                     await answer_cbq()
                 elif data.startswith("header_"):
-                    await handle_header_callback(bot, type("obj", (), {"data": data, "from_user": type("u", (), {"id": user_id}), "message": type("m", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, *args, **kwargs)})()})())
+                    await handle_header_callback(bot, type("obj", (), {"data": data, "from_user": type("u", (), {"id": user_id}), "message": type("m", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=args[0] if args else kwargs.get('text'), reply_markup=kwargs.get('reply_markup'), parse_mode=kwargs.get('parse_mode'))})()})())
                 elif data.startswith("footer_"):
-                    await handle_footer_callback(bot, type("obj", (), {"data": data, "from_user": type("u", (), {"id": user_id}), "message": type("m", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, *args, **kwargs)})()})())
+                    await handle_footer_callback(bot, type("obj", (), {"data": data, "from_user": type("u", (), {"id": user_id}), "message": type("m", (), {"edit_text": lambda *args, **kwargs: bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=args[0] if args else kwargs.get('text'), reply_markup=kwargs.get('reply_markup'), parse_mode=kwargs.get('parse_mode'))})()})()))
                 else:
                     await answer_cbq()
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
Fix `TypeError: EditMessageText.edit_message_text()` by preventing duplicate `chat_id` arguments in lambda functions.

The original lambda functions explicitly passed `chat_id=chat_id` while also forwarding `*args, **kwargs`. This caused a `TypeError` when `message.edit_text` was called and potentially passed `chat_id` again within `**kwargs`. The fix explicitly extracts `text`, `reply_markup`, and `parse_mode` from `*args` and `**kwargs` to resolve this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-20a15b94-4a2a-4ac3-9af1-abeac8842abc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20a15b94-4a2a-4ac3-9af1-abeac8842abc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

